### PR TITLE
Fix inconsistent dictionary ordering in list command

### DIFF
--- a/clearml_serving/__main__.py
+++ b/clearml_serving/__main__.py
@@ -198,7 +198,14 @@ def func_list_services(_):
         print("No running services found")
     else:
         for s in running_services:
-            print(s)
+            # Create ordered dictionary with consistent field order
+            ordered_service = {
+                'name': s.get('name', ''),
+                'tags': s.get('tags', []),
+                'id': s.get('id', ''),
+                'project': s.get('project', '')
+            }
+            print(ordered_service)
 
 
 def func_model_remove(args):


### PR DESCRIPTION
## Description
Fixes inconsistent dictionary field ordering in the `clearml-serving list` command output.

## Problem
The `list` command currently outputs dictionaries with random key ordering, causing the same service to appear with different field orders in the output.

## Solution
- Modified the list command to use consistent dictionary ordering
- Ensured fields always appear in the order: name, tags, id, project

## Testing
- Tested with multiple `clearml-serving list` calls
- Verified consistent output ordering
- No breaking changes to functionality

## Example
Before:
```
robot@robot:~$ clearml-serving list
clearml-serving - CLI for launching ClearML serving engine
Currently running Serving Services:

{'name': 'test_output', 'tags': [], 'id': '123', 'project': 'DevOps'}

robot@robot:~$ clearml-serving list
clearml-serving - CLI for launching ClearML serving engine
Currently running Serving Services:

{'tags': [], 'name': 'test_output', 'id': '123', 'project': 'DevOps'}
```

After:
```
robot@robot:~$ clearml-serving list
clearml-serving - CLI for launching ClearML serving engine
Currently running Serving Services:

{'name': 'test_output', 'tags': [], 'id': '123', 'project': 'DevOps'}

robot@robot:~$ clearml-serving list
clearml-serving - CLI for launching ClearML serving engine
Currently running Serving Services:

{'name': 'test_output', 'tags': [], 'id': '123', 'project': 'DevOps'}
```
